### PR TITLE
Adds Gemfile, changes station status endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "httparty"
+gem "thin"
+
+group :development do
+  gem "shotgun"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    daemons (1.2.3)
+    eventmachine (1.0.8)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    json (1.8.3)
+    multi_xml (0.5.5)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    shotgun (0.9.1)
+      rack (>= 1.0)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
+    tilt (2.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  httparty
+  shotgun
+  sinatra
+  thin

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+## Citibike Back End
+
+This is an app that serves to fetch (and cache) data from various
+sources as necessary and return them to the front end app. It's a simple
+proxy to avoid CORS issues and be friendly to the data services the
+front end app depends.
+
+## Getting Started
+
+Clone the app
+
+Run `bundle install`
+
+Start it up with `bundle exec shotgun`
+
+View bike data by viewing in the browser: `localhost:9393/station-status`
+
+
+## Contributing
+
+Submit a pull request

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require_relative "server"
+run CitibikeBackEnd

--- a/server.rb
+++ b/server.rb
@@ -1,9 +1,13 @@
-require 'sinatra'
-require 'HTTParty'
-require 'JSON'
+require "sinatra/base"
+require "httparty"
+require 'json'
 
-get('/') do
-  data = HTTParty.get("http://www.citibikenyc.com/stations/json")
-  parsed = JSON.parse(data.body)
-  return parsed
+class CitibikeBackEnd < Sinatra::Base
+
+  get('/') do
+    content_type :json
+
+    data = HTTParty.get("http://www.citibikenyc.com/stations/json")
+    JSON.parse(data.body).to_json
+  end
 end

--- a/server.rb
+++ b/server.rb
@@ -4,7 +4,7 @@ require 'json'
 
 class CitibikeBackEnd < Sinatra::Base
 
-  get('/') do
+  get('/station-status') do
     content_type :json
 
     data = HTTParty.get("http://www.citibikenyc.com/stations/json")


### PR DESCRIPTION
## What

Follows the "ruby way" a little more closely by adding a gemfile and establishes a more conventional way of boostrapping the app. The hope is that it's **much** easier to have other people working on the app.

Also, changes the station status endpoint from `/` to `/station-status`
## How To Test

Follow the instructions in the README.

Marvel in the beautiful JSON the app grabs from citibike and delivers to your browser.
